### PR TITLE
feat: drop support for CLI flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Paths are converted with `pathToFileURL`, so spaces, `#`, `?` and non-ASCII char
 > [!NOTE]
 > No escapes are emitted when the target stream isn't a TTY, or when `CI` is set, as they would otherwise end up in log files. Netlify is the exception, since it renders build logs as HTML and never allocates a TTY.
 
-Overrides, in order of precedence: `FORCE_HYPERLINK` (set to `0` to disable), `--no-hyperlink` / `--hyperlink` flags, then `NO_COLOR` / `NO_HYPERLINK` / `NO_HYPERLINKS`.
+Overrides, in order of precedence: `FORCE_HYPERLINK` (set to `0` to disable), then `NO_COLOR` / `NO_HYPERLINK` / `NO_HYPERLINKS`.
 
 > [!WARNING]
 > `FORCE_HYPERLINK=1` bypasses every check, including the CI and non-TTY ones. Escape sequences will end up in whatever you are redirecting to.

--- a/src/supports.ts
+++ b/src/supports.ts
@@ -28,13 +28,6 @@ function atLeast(version: Version, major: number, minor: number): boolean {
   return version.major > major || (version.major === major && version.minor >= minor)
 }
 
-function hasFlag(...flags: string[]): boolean {
-  const argv = process.argv.slice(2)
-  const end = argv.indexOf('--')
-  const args = end === -1 ? argv : argv.slice(0, end)
-  return flags.some(flag => args.includes(`--${flag}`))
-}
-
 function truthy(value: string | undefined): boolean {
   return value !== undefined && value !== '' && value !== '0' && value !== 'false'
 }
@@ -50,14 +43,6 @@ export function supportsHyperlinks(stream: StreamLike | undefined = process.stdo
 
   if (env.FORCE_HYPERLINK !== undefined) {
     return truthy(env.FORCE_HYPERLINK)
-  }
-
-  if (hasFlag('no-hyperlink', 'no-hyperlinks', 'hyperlink=false', 'hyperlink=never')) {
-    return false
-  }
-
-  if (hasFlag('hyperlink', 'hyperlink=true', 'hyperlink=always')) {
-    return true
   }
 
   // Netlify renders build logs as HTML and never allocates a TTY.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -233,17 +233,6 @@ describe('supportsHyperlinks', () => {
     expect(supportsHyperlinks(tty)).toBe(false)
   })
 
-  it('should honour --no-hyperlink and --hyperlink flags', () => {
-    const argv = process.argv
-    process.argv = ['node', 'cli', '--no-hyperlink']
-    expect(supportsHyperlinks(tty)).toBe(false)
-    process.argv = ['node', 'cli', '--hyperlink']
-    expect(supportsHyperlinks(notTty)).toBe(true)
-    process.argv = ['node', 'cli', '--', '--hyperlink']
-    expect(supportsHyperlinks(notTty)).toBe(false)
-    process.argv = argv
-  })
-
   it.each([
     ['iTerm.app', '3.0.0', false],
     ['iTerm.app', '3.1.0', true],


### PR DESCRIPTION
The various flags (e.g. `--no-hyperlink`) should really be set by the
caller rather than detected by us, i.e. they should short-circuit and
early return before calling `supportsHyperlinks`.

Otherwise, we have hidden CLI logic in our library which might surprise
some folks, but also it just means we can focus on _environment_ here
rather than CLI functionality.
